### PR TITLE
sync for tripp

### DIFF
--- a/src/sketch.js
+++ b/src/sketch.js
@@ -1,6 +1,6 @@
 import * as Tone from "tone";
 import Music from "./Music";
-import createVoices, { voiceFiles } from "./createVoices";
+import createVoices from "./createVoices";
 import createTerrain from "./createTerrain";
 import createSun from "./createSun";
 


### PR DESCRIPTION
### TL;DR

Removed unused import of `voiceFiles` from the `createVoices` module.

### What changed?

Removed the named import `voiceFiles` from the `createVoices` module in `src/sketch.js` while keeping the default import. The line changed from:
```javascript
import createVoices, { voiceFiles } from "./createVoices";
```
to:
```javascript
import createVoices from "./createVoices";
```

### How to test?

1. Run the application to ensure it still functions correctly
2. Verify that no references to `voiceFiles` are used in `sketch.js`
3. Confirm that the application builds without any errors or warnings related to unused imports

### Why make this change?

This change removes an unused import, which helps to keep the codebase clean and reduces potential confusion. Removing unused imports can also slightly improve build times and bundle size.